### PR TITLE
docu/sphinx/source/guided-tour.rst: Adapt to main as default branch

### DIFF
--- a/docu/sphinx/source/guided-tour.rst
+++ b/docu/sphinx/source/guided-tour.rst
@@ -17,7 +17,7 @@ steps:
 
 Please make sure that the framework has been properly installed if you wish to
 follow the guide. For the framework to work, the files from the `procedures folder
-<https://github.com/byte-physics/igortest/tree/master/procedures>`__
+<https://github.com/byte-physics/igortest/tree/main/procedures>`__
 should be placed into the `User Procedures` Folder of your Igor Pro setup.
 
 .. _tour_create:


### PR DESCRIPTION
Broken since at least 0ceeff70 (gitlab-ci.yml: Adapt deployment job for new default branch, 2021-03-04).