### PR TITLE
Fix: Replace if(strlen(str)) with UTF_Utils#IsEmpty

### DIFF
--- a/procedures/igortest-autorun.ipf
+++ b/procedures/igortest-autorun.ipf
@@ -111,11 +111,11 @@ Function/S GetBaseFilename()
 		SVAR/SDFR=dfr baseFilename
 	endif
 
-	if(strlen(baseFilename))
+	if(!IUTF_Utils#IsEmpty(baseFilename))
 		return baseFilename
 	endif
 
-	if(SVAR_Exists(baseFilenameOverwrite) && strlen(baseFilenameOverwrite))
+	if(SVAR_Exists(baseFilenameOverwrite) && !IUTF_Utils#IsEmpty(baseFilenameOverwrite))
 		baseFilename = baseFilenameOverwrite
 	else
 		sprintf baseFilename, "%s_%s_%s", IgorInfo(1), Secs2Date(DateTime, -2), ReplaceString(":", Secs2Time(DateTime, 3), "-")

--- a/procedures/igortest-junit.ipf
+++ b/procedures/igortest-junit.ipf
@@ -143,11 +143,11 @@ static Function/S JU_CaseToOut(testSuiteIndex, testCaseIndex)
 	endfor
 
 	message = wvTestCase[testCaseIndex][%STDOUT]
-	if(strlen(message))
+	if(!IUTF_Utils#IsEmpty(message))
 		out += "\t\t<system-out>" + JU_ToXMLCharacters(JU_TrimSOUT(message)) + "</system-out>\n"
 	endif
 	message = wvTestCase[testCaseIndex][%STDERR]
-	if(strlen(message))
+	if(!IUTF_Utils#IsEmpty(message))
 		out += "\t\t<system-err>" + JU_ToXMLCharacters(message) + "</system-err>\n"
 	endif
 
@@ -213,11 +213,11 @@ static Function/S JU_ToTestSuiteString(testRunIndex, testSuiteIndex)
 	endfor
 
 	s = wvTestSuite[testSuiteIndex][%STDOUT]
-	if(strlen(s))
+	if(!IUTF_Utils#IsEmpty(s))
 		out += "\t\t<system-out>" + JU_ToXMLCharacters(JU_TrimSOUT(s)) + "</system-out>\n"
 	endif
 	s = wvTestSuite[testSuiteIndex][%STDERR]
-	if(strlen(s))
+	if(!IUTF_Utils#IsEmpty(s))
 		out += "\t\t<system-err>" + JU_ToXMLCharacters(s) + "</system-err>\n"
 	endif
 

--- a/procedures/igortest-reporting.ipf
+++ b/procedures/igortest-reporting.ipf
@@ -205,7 +205,7 @@ static Function AddError(message, type, [incrErrorCounter])
 		wvTestCase[%CURRENT][%STATUS] = type
 		wvTestCase[%CURRENT][%NUM_ASSERT_ERROR] = num2istr(str2num(wvTestCase[%CURRENT][%NUM_ASSERT_ERROR]) + 1)
 	endif
-	if(strlen(message))
+	if(!IUTF_Utils#IsEmpty(message))
 		wvTestCase[%CURRENT][%STDERR] = AddListItem(message, wvTestCase[%CURRENT][%STDERR], "\n", Inf)
 	endif
 
@@ -513,10 +513,15 @@ threadsafe static Function IUTF_PrintStatusMessage(msg, [allowEmptyLine])
 	variable allowEmptyLine
 
 	string tmpStr
+	variable len
 
 	allowEmptyLine = ParamIsDefault(allowEmptyLine) ? 0 : !!allowEmptyLine
 
-	if(!allowEmptyLine && strlen(msg) == 0)
+	// Copy of IUTF_Tracing#IsNull() and IUTF_Tracing#IsEmpty().
+	// These functions cannot be used here as in Igor <= 8.0 can no threadsafe function use another
+	// static threadsafe function with the full name when using Independent Modules.
+	len = strlen(msg)
+	if(!allowEmptyLine && (numtype(len) == 2 || len <= 0))
 		return NaN
 	endif
 

--- a/procedures/igortest-tracing-analytics.ipf
+++ b/procedures/igortest-tracing-analytics.ipf
@@ -118,7 +118,7 @@ static Function CollectLines(WAVE totals, WAVE/T procs, STRUCT CollectionResult 
 		// of the previous function declaration
 		name = ""
 		for(j = 0; j < lineCount; j++)
-			if(!strlen(result.functions[i][j]))
+			if(IUTF_Utils#IsEmpty(result.functions[i][j]))
 				result.functions[i][j] = name
 			else
 				name = result.functions[i][j]

--- a/procedures/igortest-tracing.ipf
+++ b/procedures/igortest-tracing.ipf
@@ -457,7 +457,7 @@ static Function [WAVE/T w, string funcPath_, WAVE lineMark] AddTraceFunctions(st
 	macroIndexHelper[] = IUTF_FunctionTags#AddFunctionTagWave(wMacroList[p])
 	macroExclusionFlag[] = IUTF_FunctionTags#HasFunctionTag(wMacroList[p], UTF_FTAG_NOINSTRUMENTATION)
 	for(i = 0; i < numMacros; i += 1)
-		if(IUTF_Utils#isEmpty(procedurePath))
+		if(IUTF_Utils#IsEmpty(procedurePath))
 			procedurePath = MacroPath(wMacroList[i])
 			break
 		endif
@@ -480,12 +480,12 @@ static Function [WAVE/T w, string funcPath_, WAVE lineMark] AddTraceFunctions(st
 		endif
 		IUTF_FunctionTags#AddFunctionTagWave(fullFuncName)
 		funcExclusionFlag[i] = IUTF_FunctionTags#HasFunctionTag(fullFuncName, UTF_FTAG_NOINSTRUMENTATION)
-		if(IUTF_Utils#isEmpty(procedurePath))
+		if(IUTF_Utils#IsEmpty(procedurePath))
 			procedurePath = FunctionPath(fullFuncName)
 		endif
 	endfor
 
-	if(IUTF_Utils#isEmpty(procedurePath))
+	if(IUTF_Utils#IsEmpty(procedurePath))
 		sprintf msg, "Unable to retrieve path of procedure file %s as no macro or function could be resolved.", procWin
 		IUTF_Reporting#ReportErrorAndAbort(msg)
 	endif
@@ -928,7 +928,7 @@ static Function AnalyzeTracingResult()
 
 		do
 			FReadLine fNum, line
-			if(!strlen(line))
+			if(IUTF_Utils#IsEmpty(line))
 				break
 			endif
 			line = RemoveEnding(line, "\r\n")

--- a/procedures/igortest-utils-strings.ipf
+++ b/procedures/igortest-utils-strings.ipf
@@ -50,7 +50,7 @@ static Function/S UserPrintF(format, strings, numbers, err)
 		return result
 	endif
 
-	for(; strlen(format);)
+	for(; !IUTF_Utils#IsEmpty(format);)
 		SplitString/E=USER_PRINT_PATTERN format, part1, part2, part3
 		num = V_flag
 

--- a/procedures/igortest-utils.ipf
+++ b/procedures/igortest-utils.ipf
@@ -73,16 +73,15 @@ threadsafe static Function IsNull(str)
 	return numtype(len) == 2
 End
 
-/// @brief Returns one if str is empty or null, zero otherwise.
-/// @param str must not be a SVAR
+/// @brief Returns one if str is empty, zero otherwise.
+/// @param str any non-null string variable or text wave element
 ///
 /// @hidecallgraph
 /// @hidecallergraph
 threadsafe static Function IsEmpty(str)
-	string& str
+	string str
 
-	variable len = strlen(str)
-	return numtype(len) == 2 || len <= 0
+	return !(strlen(str) > 0)
 End
 
 /// @brief Returns one if var is a nonfinite integer, zero otherwise


### PR DESCRIPTION
Strings from function arguments can be null and should be untrusted.
Using if(strlen(str)) to the check if its empty is therefore insecure
and prone to errors. These calls have been replaced with the better
UTF_Utils#IsEmpty.

Not all if(strlen(str)) are insecure and therefore only the mentioned
case is updated. If the string originate from a wave or an SVAR, which
cannot be null, the code if(strlen(str)) is kept and not replaced.

Close #303