### PR TITLE
Fix long wave labels

### DIFF
--- a/procedures/igortest-basics.ipf
+++ b/procedures/igortest-basics.ipf
@@ -638,7 +638,7 @@ End
 static Function GetTestCaseCount([procWin])
 	string procWin
 
-	variable i, j, size, dgenSize
+	variable i, j, size, dgenSize, index
 	variable tcCount, dgenCount
 	string dgenList, dgen
 
@@ -655,7 +655,8 @@ static Function GetTestCaseCount([procWin])
 		dgenSize = ItemsInList(dgenList)
 		for(j = 0; j < dgenSize; j += 1)
 			dgen = StringFromList(j, dgenList)
-			WAVE wv = dgenWaves[%$dgen]
+			index = IUTF_Test_MD_Gen#GetDataGeneratorRef(dgen)
+			WAVE wv = dgenWaves[index]
 			dgenCount *= DimSize(wv, UTF_ROW)
 		endfor
 		tcCount += dgenCount
@@ -959,7 +960,7 @@ static Function CallTestCase(s, reentry)
 
 	STRUCT IUTF_mData mData
 
-	variable wType0, wType1, wRefSubType, err, tcIndex
+	variable wType0, wType1, wRefSubType, err, tcIndex, refIndex
 	string func, msg, dgenFuncName, origTCName, funcInfo
 
 	WAVE/T testRunData = GetTestRunData()
@@ -987,7 +988,8 @@ static Function CallTestCase(s, reentry)
 
 		WAVE/WAVE dgenWaves = IUTF_Test_MD_Gen#GetDataGeneratorWaves()
 		dgenFuncName = StringFromList(0, testRunData[tcIndex][%DGENLIST])
-		WAVE wGenerator = dgenWaves[%$dgenFuncName]
+		refIndex = IUTF_Test_MD_Gen#GetDataGeneratorRef(dgenFuncName)
+		WAVE wGenerator = dgenWaves[refIndex]
 		wType0 = WaveType(wGenerator)
 		wType1 = WaveType(wGenerator, 1)
 		if(wType1 == IUTF_WAVETYPE1_NUM)
@@ -1248,11 +1250,12 @@ static Function ClearTestSetupWaves()
 
 	WAVE/T testRunData = GetTestRunData()
 	WAVE/WAVE dgenWaves = IUTF_Test_MD_Gen#GetDataGeneratorWaves()
+	WAVE/T dgenRefs = IUTF_Test_MD_Gen#GetDataGeneratorRefs()
 	WAVE/WAVE ftagWaves = IUTF_FunctionTags#GetFunctionTagWaves()
 	WAVE/WAVE ftagRefs = IUTF_FunctionTags#GetFunctionTagRefs()
 	WAVE/WAVE mdState = IUTF_Test_MD_MMD#GetMMDataState()
 
-	KillWaves testRunData, dgenWaves, ftagWaves, ftagRefs, mdState
+	KillWaves testRunData, dgenWaves, dgenRefs, ftagWaves, ftagRefs, mdState
 End
 
 /// @brief Detects if deprecated files are included and prompt a warning.
@@ -1634,7 +1637,8 @@ Function RunTest(procWinList, [name, testCase, enableJU, enableTAP, enableRegExp
 			else
 				s.mdMode = TC_MODE_MD
 				dgenFuncName = StringFromList(0, testRunData[s.i][%DGENLIST])
-				WAVE wGenerator = dgenWaves[%$dgenFuncName]
+				var = IUTF_Test_MD_Gen#GetDataGeneratorRef(dgenFuncName)
+				WAVE wGenerator = dgenWaves[var]
 				s.dgenSize = DimSize(wGenerator, UTF_ROW)
 			endif
 
@@ -1646,7 +1650,8 @@ Function RunTest(procWinList, [name, testCase, enableJU, enableTAP, enableRegExp
 
 				if(s.mdMode == TC_MODE_MD)
 					dgenFuncName = StringFromList(0, testRunData[s.i][%DGENLIST])
-					WAVE wGenerator = dgenWaves[%$dgenFuncName]
+					var = IUTF_Test_MD_Gen#GetDataGeneratorRef(dgenFuncName)
+					WAVE wGenerator = dgenWaves[var]
 					s.tcSuffix = ":" + GetDimLabel(wGenerator, UTF_ROW, s.dgenIndex)
 					if(strlen(s.tcSuffix) == 1)
 						s.tcSuffix = IUTF_TC_SUFFIX_SEP + num2istr(s.dgenIndex)

--- a/procedures/igortest-basics.ipf
+++ b/procedures/igortest-basics.ipf
@@ -1254,8 +1254,9 @@ static Function ClearTestSetupWaves()
 	WAVE/WAVE ftagWaves = IUTF_FunctionTags#GetFunctionTagWaves()
 	WAVE/WAVE ftagRefs = IUTF_FunctionTags#GetFunctionTagRefs()
 	WAVE/WAVE mdState = IUTF_Test_MD_MMD#GetMMDataState()
+	WAVE/T mdStateRefs = IUTF_Test_MD_MMD#GetMMDataStateRefs()
 
-	KillWaves testRunData, dgenWaves, dgenRefs, ftagWaves, ftagRefs, mdState
+	KillWaves testRunData, dgenWaves, dgenRefs, ftagWaves, ftagRefs, mdState, mdStateRefs
 End
 
 /// @brief Detects if deprecated files are included and prompt a warning.

--- a/procedures/igortest-functiontags.ipf
+++ b/procedures/igortest-functiontags.ipf
@@ -64,17 +64,9 @@ End
 static Function GetFunctionTagRef(fullFuncName)
 	string fullFuncName
 
-	variable length
 	WAVE/T ftagRefs = GetFunctionTagRefs()
 
-#if (IgorVersion() >= 8.00)
-	length = IUTF_Utils_Vector#GetLength(ftagRefs)
-	FindValue/Z/TEXT=(fullFuncName)/TXOP=5/RMD=[0, length - 1] ftagRefs
-#else
-	FindValue/Z/TEXT=(fullFuncName)/TXOP=5 ftagRefs
-#endif
-
-	return V_value
+	return IUTF_Utils_Vector#FindText(ftagRefs, fullFuncName)
 End
 
 /// @brief returns 1 if the comments above a function contain a certain tag, zero otherwise

--- a/procedures/igortest-test-md-mmd.ipf
+++ b/procedures/igortest-test-md-mmd.ipf
@@ -139,7 +139,7 @@ static Function SetupMMDStruct(mData, fullFuncName)
 	string fullFuncName
 
 	variable i, j, numTypes
-	variable funPos, varPos, index, val
+	variable funPos, varPos, index, val, refIndex
 	variable/C cplx
 	string msg, varName, dgen, str
 #if (IgorVersion() >= 7.0)
@@ -165,7 +165,8 @@ static Function SetupMMDStruct(mData, fullFuncName)
 
 			strSwitch(templates[i])
 				case DGEN_VAR_TEMPLATE:
-					WAVE wGenerator = dgenWaves[%$dgen]
+					refIndex = IUTF_Test_MD_Gen#GetDataGeneratorRef(dgen)
+					WAVE wGenerator = dgenWaves[refIndex]
 					val = wGenerator[index]
 
 					switch(j)
@@ -190,7 +191,8 @@ static Function SetupMMDStruct(mData, fullFuncName)
 					endswitch
 					break
 				case DGEN_STR_TEMPLATE:
-					WAVE/T wGeneratorT = dgenWaves[%$dgen]
+					refIndex = IUTF_Test_MD_Gen#GetDataGeneratorRef(dgen)
+					WAVE/T wGeneratorT = dgenWaves[refIndex]
 					str = wGeneratorT[index]
 
 					switch(j)
@@ -215,7 +217,8 @@ static Function SetupMMDStruct(mData, fullFuncName)
 					endswitch
 					break
 				case DGEN_DFR_TEMPLATE:
-					WAVE/DF wGeneratorDFR = dgenWaves[%$dgen]
+					refIndex = IUTF_Test_MD_Gen#GetDataGeneratorRef(dgen)
+					WAVE/DF wGeneratorDFR = dgenWaves[refIndex]
 					DFREF dfr = wGeneratorDFR[index]
 
 					switch(j)
@@ -240,7 +243,8 @@ static Function SetupMMDStruct(mData, fullFuncName)
 					endswitch
 					break
 				case DGEN_WAVE_TEMPLATE:
-					WAVE/WAVE wGeneratorWV = dgenWaves[%$dgen]
+					refIndex = IUTF_Test_MD_Gen#GetDataGeneratorRef(dgen)
+					WAVE/WAVE wGeneratorWV = dgenWaves[refIndex]
 					WAVE wv = wGeneratorWV[index]
 
 					switch(j)
@@ -265,7 +269,8 @@ static Function SetupMMDStruct(mData, fullFuncName)
 					endswitch
 					break
 				case DGEN_CMPLX_TEMPLATE:
-					WAVE/C wGeneratorC = dgenWaves[%$dgen]
+					refIndex = IUTF_Test_MD_Gen#GetDataGeneratorRef(dgen)
+					WAVE/C wGeneratorC = dgenWaves[refIndex]
 					cplx = wGeneratorC[index]
 
 					switch(j)
@@ -291,7 +296,8 @@ static Function SetupMMDStruct(mData, fullFuncName)
 					break
 #if (IgorVersion() >= 7.0)
 				case DGEN_INT64_TEMPLATE:
-					WAVE wGeneratorI = dgenWaves[%$dgen]
+					refIndex = IUTF_Test_MD_Gen#GetDataGeneratorRef(dgen)
+					WAVE wGeneratorI = dgenWaves[refIndex]
 					i64 = wGeneratorI[index]
 
 					switch(j)
@@ -391,7 +397,7 @@ EndStructure
 static Function/S GetMMDTCSuffix(tdIndex)
 	variable tdIndex
 
-	variable i, numVars, index
+	variable i, numVars, index, refIndex
 	string fullFuncName, dgen, lbl
 	string tcSuffix = ""
 
@@ -406,7 +412,8 @@ static Function/S GetMMDTCSuffix(tdIndex)
 	for(i = 0; i < numVars; i += 1)
 		dgen = mdFunState[i][%DATAGEN]
 		index = str2num(mdFunState[i][%INDEX])
-		WAVE wGenerator = dgenWaves[%$dgen]
+		refIndex = IUTF_Test_MD_Gen#GetDataGeneratorRef(dgen)
+		WAVE wGenerator = dgenWaves[refIndex]
 		lbl = GetDimLabel(wGenerator, UTF_ROW, index)
 		if(!IUTF_Utils#IsEmpty(lbl))
 			tcSuffix += IUTF_TC_SUFFIX_SEP + lbl

--- a/procedures/igortest-utils-vector.ipf
+++ b/procedures/igortest-utils-vector.ipf
@@ -129,3 +129,26 @@ static Function AddRows(wv, count)
 
 	return newLength - 1
 End
+
+/// @brief Find the requested string inside the text wave. The full string has to match. If the
+/// requested text is found multiple times in the wave it will return one of them.
+///
+/// @param wv    The text vector to search in
+/// @param text  The string to search
+///
+/// @returns The index if found or -1 if not.
+static Function FindText(wv, text)
+	WAVE/T wv
+	string text
+
+	variable length
+
+	#if (IgorVersion() >= 8.00)
+	length = GetLength(wv)
+	FindValue/Z/TEXT=(text)/TXOP=5/RMD=[0, length - 1] wv
+#else
+	FindValue/Z/TEXT=(text)/TXOP=5 wv
+#endif
+
+	return V_value
+End


### PR DESCRIPTION
MMDataState and DataGeneratorWaves used the full function names as wave label to find its
entries. This can lead to bugs when the full function name becomes
larger than the supported wave label size. This is fixed using a second
text wave to store the function names at the same index as the entries
in MMDataState or DataGeneratorWaves.

This is the same fix as in 0309a67 (Function Tags: Fix long function
name bug, 2023-01-18).

Close #390