### PR TITLE
*_EQUAL_STR and *_NEQ_STR are now pass-by-value

### DIFF
--- a/procedures/igortest-assertion-wrappers.ipf
+++ b/procedures/igortest-assertion-wrappers.ipf
@@ -4,6 +4,7 @@
 #pragma TextEncoding="UTF-8"
 #pragma ModuleName=IUTF_Wrapper
 
+static Constant RTE_NULL_STRING = 185
 
 /// @class INFO_DOCU
 /// Append information to the next assertion to print if failed
@@ -201,6 +202,10 @@ End
 /// @class NEQ_STR_DOCU
 /// Compares two strings for unequality
 ///
+/// This doesn't check if one of the two string are null. If this function is called with a null
+/// string this will throw a check assertion error. The same will happen if you call this function
+/// and there is a pending code 185 runtime error.
+///
 /// @param str1            first string
 /// @param str2            second string
 /// @param case_sensitive  (optional) should the comparison be done case sensitive (1) or case insensitive (0, the default)
@@ -220,6 +225,13 @@ static Function NEQ_STR_WRAPPER(str1, str2, flags, [case_sensitive])
 
 	if(ParamIsDefault(case_sensitive))
 		case_sensitive = 1
+	endif
+
+	if(GetRTError(0) == RTE_NULL_STRING)
+		IUTF_Basics#ClearRTError()
+		str = "Null string error: One of the provided arguments could be an unsupported null string."
+		EvaluateResults(0, str, CHECK_MODE)
+		return NaN
 	endif
 
 	result = !IUTF_Checks#AreStringsEqual(str1, str2, case_sensitive)
@@ -487,7 +499,11 @@ End
 /// @endcond
 
 /// @class EQUAL_STR_DOCU
-/// Compares two strings for byte-wise equality. (no encoding considered, no unicode normalization)
+/// Compares two strings for byte-wise equality. (no encoding considered, no unicode normalization).
+///
+/// This doesn't check if one of the two string are null. If this function is called with a null
+/// string this will throw a check assertion error. The same will happen if you call this function
+/// and there is a pending code 185 runtime error.
 ///
 /// @param str1           first string
 /// @param str2           second string
@@ -509,6 +525,13 @@ static Function EQUAL_STR_WRAPPER(str1, str2, flags, [case_sensitive])
 
 	if(ParamIsDefault(case_sensitive))
 		case_sensitive = 1
+	endif
+
+	if(GetRTError(0) == RTE_NULL_STRING)
+		IUTF_Basics#ClearRTError()
+		str = "Null string error: One of the provided arguments could be an unsupported null string."
+		EvaluateResults(0, str, CHECK_MODE)
+		return NaN
 	endif
 
 	result = IUTF_Checks#AreStringsEqual(str1, str2, case_sensitive)

--- a/procedures/igortest-assertions.ipf
+++ b/procedures/igortest-assertions.ipf
@@ -725,7 +725,7 @@ End
 
 /// @copydoc EQUAL_STR_DOCU
 Function WARN_EQUAL_STR(str1, str2, [case_sensitive])
-	string &str1, &str2
+	string str1, str2
 	variable case_sensitive
 
 	if(ParamIsDefault(case_sensitive))
@@ -737,7 +737,7 @@ End
 
 /// @copydoc EQUAL_STR_DOCU
 Function CHECK_EQUAL_STR(str1, str2, [case_sensitive])
-	string &str1, &str2
+	string str1, str2
 	variable case_sensitive
 
 	if(ParamIsDefault(case_sensitive))
@@ -749,7 +749,7 @@ End
 
 /// @copydoc EQUAL_STR_DOCU
 Function REQUIRE_EQUAL_STR(str1, str2, [case_sensitive])
-	string &str1, &str2
+	string str1, str2
 	variable case_sensitive
 
 	if(ParamIsDefault(case_sensitive))
@@ -761,7 +761,7 @@ End
 
 /// @copydoc NEQ_STR_DOCU
 Function WARN_NEQ_STR(str1, str2, [case_sensitive])
-	string &str1, &str2
+	string str1, str2
 	variable case_sensitive
 
 	if(ParamIsDefault(case_sensitive))
@@ -773,7 +773,7 @@ End
 
 /// @copydoc NEQ_STR_DOCU
 Function CHECK_NEQ_STR(str1, str2, [case_sensitive])
-	string &str1, &str2
+	string str1, str2
 	variable case_sensitive
 
 	if(ParamIsDefault(case_sensitive))
@@ -785,7 +785,7 @@ End
 
 /// @copydoc NEQ_STR_DOCU
 Function REQUIRE_NEQ_STR(str1, str2, [case_sensitive])
-	string &str1, &str2
+	string str1, str2
 	variable case_sensitive
 
 	if(ParamIsDefault(case_sensitive))

--- a/tests/TestResultsTests/FailedTests.ipf
+++ b/tests/TestResultsTests/FailedTests.ipf
@@ -138,3 +138,39 @@ static Function EmptyExpected_Verify()
 	result = tc[0][%NUM_ASSERT]
 	CHECK_EQUAL_STR(expect, result)
 End
+
+static Function NullStringAccess()
+	string nullstr
+
+	CHECK_EQUAL_STR(nullstr, nullstr)
+End
+
+static Function NullStringAccess_Verify()
+	string expect, result, stdErr
+	variable childStart, childEnd
+
+	WAVE/T/Z tc = Utils#LastTestCase()
+	INFO("Bug: test case not found")
+	REQUIRE(WaveExists(tc))
+
+	Utils#ExpectTestCaseStatus(IUTF_STATUS_FAIL)
+
+	childStart = str2num(tc[0][%CHILD_START])
+	childEnd = str2num(tc[0][%CHILD_END])
+	INFO("Check if exactly one assertion was thrown")
+	CHECK_EQUAL_VAR(1, childEnd - childStart)
+
+	stdErr = tc[0][%STDERR]
+	INFO("Check if stderr is not empty")
+	CHECK_NON_EMPTY_STR(stdErr)
+
+	INFO("Check if one assertion errors is set")
+	expect = "1"
+	result = tc[0][%NUM_ASSERT_ERROR]
+	CHECK_EQUAL_STR(expect, result)
+
+	INFO("Check if the assertion counter is correct")
+	expect = "1"
+	result = tc[0][%NUM_ASSERT]
+	CHECK_EQUAL_STR(expect, result)
+End


### PR DESCRIPTION
The string paramater for WARN_EQUAL_STR, CHECK_EQUAL_STR,
REQUIRE_EQUAL_STR, WARN_NEQ_STR, CHECK_NEQ_STR and REQUIRE_NEQ_STR are
now pass-by-value. This allows simpler usage and unify the api for the
*_EQUAL_* and *_NEQ_* variants.

These assertions were originally designed to be pass-by-reference to
catch the edge-case when the user provide a null string. There is no
longer a need take this in account as there are *_NULL_STR and
*_PROPER_STR assertions that are designed to check for these edge cases.

Close #363