### PR TITLE
Add *_RTE, *_ANY_RTE and *_NO_RTE assertions

### DIFF
--- a/docu/examples/example8-uncaught-runtime-errors.ipf
+++ b/docu/examples/example8-uncaught-runtime-errors.ipf
@@ -7,12 +7,12 @@
 
 Function TestWaveOp()
 
-		Wave wv = $""
-		print wv[0]
-		print "This will be printed, even if a RTE occurs."
+	Wave wv = $""
+	print wv[0]
+	print "This will be printed, even if a RTE occurs."
 
-		WAVE/Z/SDFR=$"I dont exist" wv; AbortOnRTE
-		print "This will not be printed, as AbortOnRTE aborts the test case."
+	WAVE/Z/SDFR=$"I dont exist" wv; AbortOnRTE
+	print "This will not be printed, as AbortOnRTE aborts the test case."
 End
 
 Function TestWaveOpSelfCatch()

--- a/docu/examples/example8-uncaught-runtime-errors.ipf
+++ b/docu/examples/example8-uncaught-runtime-errors.ipf
@@ -15,17 +15,30 @@ Function TestWaveOp()
 	print "This will not be printed, as AbortOnRTE aborts the test case."
 End
 
-Function TestWaveOpSelfCatch()
+Function CheckForRTEs()
 
+	Wave wv = $""
+	print wv[0]
+	// Check if any RTE occurs. If no RTE exists at this point it will create an assertion error.
+	CHECK_ANY_RTE()
+
+	WAVE/SDFR=$"I dont exist" wv
+	// Check for a specific error code. If a different RTE or no RTE exists at this point it will
+	// create an assertion error.
+	CHECK_RTE(394)
+
+	print "This will always be printed and at this point there a no active RTE as all of them are handled."
+
+	// If you want to test for RTEs and aborts at the same time you can do this doing this:
 	try
-		WAVE/Z/SDFR=$"I dont exist" wv; AbortOnRTE
-		// If an RTE happens, the execution will jump to catch.
-		PASS()
+		// info has to be set before the function call
+		INFO("checks if CustomUserFunction returns with no RTE or aborts")
+		CustomUserFunction()
+		CHECK_NO_RTE()
 	catch
-		print "Here you can print additional info to understand the RTE."
-		// There is no need to clear the RTE (e.g. with GetRTError(1) )
-		// RunTest will take care and print the error message.
+		INFO("CustomUserFunction returned with an abort")
 		FAIL()
 	endtry
-	print "I only get printed when no RTE occurs"
+
+	// more tests ...
 End

--- a/docu/sphinx/source/examples.rst
+++ b/docu/sphinx/source/examples.rst
@@ -311,22 +311,27 @@ every RTE at its correct line you can open the debugger with:
    RunTest(..., debugMode = IUTF_DEBUG_ON_ERROR)
 
 
-There might be situations where the user wants to catch a runtime error
-himself. In line 17 :code:`TestWaveOpSelfCatch` shows how to catch the RTE
-before the test environment handles it. Do not use :code:`GetRTError(1)`,
-as it clears the RTE and thereby masks it from the Test environment.
+There might be situations when the user wants to check if certain functions or
+statements return a runtime error and handle it. For this exists
+:code:`CHECK_RTE`, :code:`CHECK_ANY_RTE` and :code:`CHECK_NO_RTE` that can help
+in this situation. These assertions check the current RTE state and create an
+error if the current state is unexpected. They will also clear any pending RTE
+so its safe to continue execution.
 
-In the second function, if :code:`AbortOnRTE` is activated the execution jumps
-to :code:`catch`. Here the user can generate additional information on the RTE,
-before :cpp:func:`FAIL` increases the error counter and aborts the test run.
-So TestWaveOpSelfCatch reports two errors, one from FAIL and one from the
-uncaught RTE.
+These assertions are shown in the second function. This function also includes
+an example how the user can check for RTEs and aborts at the same time.
+
+When using :code:`CHECK_RTE`, :code:`CHECK_ANY_RTE` or :code:`CHECK_NO_RTE` the
+user has to keep in mind that any :code:`INFO` has to be called before the
+critical statement as :code:`INFO` does nothing when a pending RTE exists to
+keep the error state unchanged.
+
 
 .. literalinclude:: ../../examples/example8-uncaught-runtime-errors.ipf
    :caption: example8-uncaught-runtime-errors
    :tab-width: 4
    :linenos:
-   :emphasize-lines: 10,13,20
+   :emphasize-lines: 10,14,21,25,34
 
 .. code-block:: igor
    :caption: command

--- a/procedures/igortest-assertion-checks.ipf
+++ b/procedures/igortest-assertion-checks.ipf
@@ -386,4 +386,20 @@ static Function/S GetWaveMinorTypeString(type)
 	return RemoveEnding(str, ", ")
 End
 
+static Function HasRTE(code)
+	variable code
+
+	variable rte = GetRTError(0)
+
+	return rte == code
+End
+
+static Function HasAnyRTE()
+	variable code
+
+	variable rte = GetRTError(0)
+
+	return !!rte
+End
+
 /// @endcond // HIDDEN_SYMBOL

--- a/procedures/igortest-assertion-wrappers.ipf
+++ b/procedures/igortest-assertion-wrappers.ipf
@@ -902,3 +902,83 @@ static Function GREATER_THAN_VAR_WRAPPER(var1, var2, flags)
 	sprintf str, "%s > %s", tmpStr1, tmpStr2
 	EvaluateResults(result, str, flags)
 End
+
+static Function/S RTE2String(code, [msg])
+	variable code
+	string msg
+
+	string result
+
+	if(code)
+		if(ParamIsDefault(msg))
+			sprintf result, "RTE %d", code
+		else
+			sprintf result, "RTE %d \"%s\"", code, msg
+		endif
+		return result
+	else
+		return "no RTE"
+	endif
+End
+
+/// @class RTE_DOCU
+/// Tests if a RTE with the specified code was thrown. This assertion will clear any pending RTEs.
+///
+/// Hint: You have to add INFO() statements before the statement that is tested. INFO() won't do
+/// something if a pending RTE exists.
+///
+/// @param code the code that is expected to be thrown
+static Function RTE_WRAPPER(code, flags)
+	variable code, flags
+
+	variable result, err
+	string str, msg
+
+	IUTF_Reporting#incrAssert()
+
+	if(shouldDoAbort())
+		return NaN
+	endif
+
+	result = IUTF_Checks#HasRTE(code)
+	msg = GetRTErrMessage()
+	err = GetRTError(1)
+
+	sprintf str, "Expecting %s but got %s", RTE2String(code), RTE2String(err, msg = msg)
+	EvaluateResults(result, str, flags)
+End
+
+/// @class ANY_RTE_DOCU
+/// Tests if any RTE was thrown. This assertion will clear any pending RTEs.
+///
+/// Hint: You have to add INFO() statements before the statement that is tested. INFO() won't do
+/// something if a pending RTE exists.
+static Function ANY_RTE_WRAPPER(flags)
+	variable flags
+
+	variable result, err
+	string str
+
+	IUTF_Reporting#incrAssert()
+
+	if(shouldDoAbort())
+		return NaN
+	endif
+
+	result = IUTF_Checks#HasAnyRTE()
+	err = GetRTError(1)
+
+	sprintf str, "Expecting any RTE but got nothing"
+	EvaluateResults(result, str, flags)
+End
+
+/// @class NO_RTE_DOCU
+/// Tests if no RTEs are thrown. This assertion will clear any pending RTEs.
+///
+/// Hint: You have to add INFO() statements before the statement that is tested. INFO() won't do
+/// something if a pending RTE exists.
+static Function NO_RTE_WRAPPER(flags)
+	variable flags
+
+	RTE_WRAPPER(0, flags)
+End

--- a/procedures/igortest-assertions.ipf
+++ b/procedures/igortest-assertions.ipf
@@ -981,4 +981,52 @@ Function REQUIRE_EMPTY_FOLDER()
 	IUTF_Wrapper#CDF_EMPTY_WRAPPER(REQUIRE_MODE)
 End
 
+/// @copydoc RTE_DOCU
+Function WARN_RTE(code)
+	variable code
+	IUTF_Wrapper#RTE_WRAPPER(code, WARN_MODE)
+End
+
+/// @copydoc RTE_DOCU
+Function CHECK_RTE(code)
+	variable code
+	IUTF_Wrapper#RTE_WRAPPER(code, CHECK_MODE)
+End
+
+/// @copydoc RTE_DOCU
+Function REQUIRE_RTE(code)
+	variable code
+	IUTF_Wrapper#RTE_WRAPPER(code, REQUIRE_MODE)
+End
+
+/// @copydoc ANY_RTE_DOCU
+Function WARN_ANY_RTE()
+	IUTF_Wrapper#ANY_RTE_WRAPPER(WARN_MODE)
+End
+
+/// @copydoc ANY_RTE_DOCU
+Function CHECK_ANY_RTE()
+	IUTF_Wrapper#ANY_RTE_WRAPPER(CHECK_MODE)
+End
+
+/// @copydoc ANY_RTE_DOCU
+Function REQUIRE_ANY_RTE()
+	IUTF_Wrapper#ANY_RTE_WRAPPER(REQUIRE_MODE)
+End
+
+/// @copydoc NO_RTE_DOCU
+Function WARN_NO_RTE()
+	IUTF_Wrapper#NO_RTE_WRAPPER(WARN_MODE)
+End
+
+/// @copydoc NO_RTE_DOCU
+Function CHECK_NO_RTE()
+	IUTF_Wrapper#NO_RTE_WRAPPER(CHECK_MODE)
+End
+
+/// @copydoc NO_RTE_DOCU
+Function REQUIRE_NO_RTE()
+	IUTF_Wrapper#NO_RTE_WRAPPER(REQUIRE_MODE)
+End
+
 ///@}

--- a/tests/VTTE.ipf
+++ b/tests/VTTE.ipf
@@ -31,6 +31,7 @@ End
 // This is done so that we don't rely on the IUTF test case discovery logic to work.
 static Function TestIUTF()
 	variable err
+	string str
 
 	PASS()
 
@@ -706,6 +707,52 @@ static Function TestIUTF()
 	CHECK_WAVE($"", NULL_WAVE)
 	CHECK_WAVE({0}, NUMERIC_WAVE, minorType = FLOAT_WAVE)
 
+	// @}
+
+	// HasRTE/HasAnyRTE
+	// @{
+	WAVE/Z nullWave = $""
+	nullWave[0] = 0
+	Ensure(!IUTF_Checks#HasRTE(0))
+	Ensure(IUTF_Checks#HasRTE(330))
+	Ensure(!IUTF_Checks#HasRTE(185))
+	Ensure(IUTF_Checks#HasAnyRTE())
+	err = GetRTError(1)
+
+	str = nullstr[0]
+	Ensure(!IUTF_Checks#HasRTE(0))
+	Ensure(!IUTF_Checks#HasRTE(330))
+	Ensure(IUTF_Checks#HasRTE(185))
+	Ensure(IUTF_Checks#HasAnyRTE())
+	err = GetRTError(1)
+
+	Ensure(IUTF_Checks#HasRTE(0))
+	Ensure(!IUTF_Checks#HasRTE(330))
+	Ensure(!IUTF_Checks#HasRTE(185))
+	Ensure(!IUTF_Checks#HasAnyRTE())
+	// @}
+
+	// CHECK_RTE, CHECK_ANY_RTE, CHECK_NO_RTE
+	// @{
+	CHECK_NO_RTE()
+
+	nullWave[0] = 0
+	CHECK_RTE(330)
+	Ensure(!GetRTError(1))
+
+	str = nullstr[0]
+	CHECK_RTE(185)
+	Ensure(!GetRTError(1))
+
+	nullWave[0] = 0
+	CHECK_ANY_RTE()
+	Ensure(!GetRTError(1))
+
+	str = nullstr[0]
+	CHECK_ANY_RTE()
+	Ensure(!GetRTError(1))
+
+	CHECK_NO_RTE()
 	// @}
 
 	// UserPrintF

--- a/tests/VTTE.ipf
+++ b/tests/VTTE.ipf
@@ -175,8 +175,6 @@ static Function TestIUTF()
 	Ensure(!IUTF_Checks#AreStringsEqual(randomstr, anotherrandomstr, NaN))
 	// @}
 
-	CHECK_NEQ_STR(properstr, nullstr)
-
 	CHECK_EQUAL_STR(randomstr, randomstr)
 	CHECK_EQUAL_STR(randomstr, randomstr, case_sensitive = 1)
 


### PR DESCRIPTION
These assertions check the current RTE state and create an error if its
unexpected. This simplifies the user code to check for RTEs during
runtime.

Close #339