### PR TITLE
Fix CI: Move to correct folder

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -239,7 +239,7 @@ deployment:
   variables:
     DOCKER_AUTH_CONFIG: "${DOCKER_AUTH_CONFIG_UTILS}"
   script:
-    - mv report build/html/
+    - mv report docu/sphinx/build/html/
     - cd docu/sphinx
     - lftp -e "mirror --reverse -n -e build/html /igortest; bye" -u $FTP_USER_DOCS,$FTP_PW_DOCS byte-physics.de
   needs:


### PR DESCRIPTION
bcbfd75 (CI: Add Cobertura HTML report generator output, 2023-02-27)
added the wrong path for the deployment step.