### PR TITLE
Readme: Add coverage badge

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -4,6 +4,7 @@
 [![GitHub release (latest by date)](https://img.shields.io/github/v/release/byte-physics/igortest?style=plastic)](https://github.com/byte-physics/igortest/releases)
 [![License](https://img.shields.io/github/license/byte-physics/igortest?style=plastic)](https://github.com/byte-physics/igortest/blob/main/License.txt)
 [![REUSE status](https://api.reuse.software/badge/github.com/byte-physics/igortest)](https://api.reuse.software/info/github.com/byte-physics/igortest)
+[![Line/Branch/Method Coverage](https://docs.byte-physics.de/igortest/report/badge_combined.svg)](https://docs.byte-physics.de/igortest/report/)
 
 The **Igor Pro Universal Testing Framework** (IUTF) is a versatile tool to write and run tests for [Igor Pro](https://www.wavemetrics.com/products/igorpro) code.
 The results of the tests is outputted in standardized formats that can be parsed by common


### PR DESCRIPTION
This badge is an animated svg which shows the current line-coverage,
branch-coverage and method-coverage of the latest push to the main
branch.

The badges are created since bcbfd75 (CI: Add Cobertura HTML report
generator output, 2023-02-27).