### PR TITLE
Clear abort flag at the begin of RunTest

### DIFF
--- a/procedures/igortest-basics.ipf
+++ b/procedures/igortest-basics.ipf
@@ -1609,6 +1609,7 @@ Function RunTest(procWinList, [name, testCase, enableJU, enableTAP, enableRegExp
 		IUTF_Reporting#ClearTestResultWaves()
 		ClearBaseFilename()
 		CreateHistoryLog()
+		InitAbortFlag()
 		IUTF_Reporting_Control#SetupTestRun()
 
 		allowDebug = ParamIsDefault(allowDebug) ? 0 : !!allowDebug


### PR DESCRIPTION
This prevents that an abortflag from a previous RunTest has some
influence for data generator of the current RunTest. Previously, the
abort flag is cleared at the test run begin hook which is called after
the data generator.

Close #431