### PR TITLE
GenerateDimLabelDifference: Don't ignore case

### DIFF
--- a/docu/sphinx/source/changelog.rst
+++ b/docu/sphinx/source/changelog.rst
@@ -50,6 +50,8 @@ The format is based on `Keep a Changelog <https://keepachangelog.com/en/1.0.0/>`
   and the `original article page 36 <https://web.archive.org/web/20220329072759/http://www.mccabe.com/ppt/SoftwareQualityMetricsToIdentifyRisk.ppt>`__
 - Fixed a bug where when running IUTF in an independent module, the ``run`` function was searched in ``ProcGlobal``
   instead of the independent module.
+- Fixed a bug where generating the detailed message for failed wave equality assertions did not ignore the case for
+  comparing dimension labels.
 
 Test assertions
 ~~~~~~~~~~~~~~~

--- a/procedures/igortest-basics.ipf
+++ b/procedures/igortest-basics.ipf
@@ -206,7 +206,7 @@ Function GenerateDimLabelDifference(wv1, wv2, msg)
 
 			numEntries = DimSize(label1, i)
 			for(j = 0; j < numEntries; j += 1)
-				if(!cmpstr(label1[j], label2[j]))
+				if(!cmpstr(label1[j], label2[j], 1))
 					continue
 				endif
 				str1 = label1[j]

--- a/tests/VTTE.ipf
+++ b/tests/VTTE.ipf
@@ -459,6 +459,14 @@ static Function TestIUTF()
 	Ensure(!IUTF_Checks#AreWavesEqual(wvDP, wvSP, WAVE_LOCK_STATE, DEFAULT_TOLERANCE, detailedMsg))
 	Ensure(!IUTF_Checks#AreWavesEqual(wvDP, wvSP, DATA_FULL_SCALE, DEFAULT_TOLERANCE, detailedMsg))
 	Ensure(!IUTF_Checks#AreWavesEqual(wvDP, wvSP, DIMENSION_SIZES, DEFAULT_TOLERANCE, detailedMsg))
+
+	Make/FREE dimLabel1, dimLabel2
+
+	SetDimLabel 0, 0, abcd, dimLabel1
+	SetDimLabel 0, 0, abcD, dimLabel2
+	Ensure(!IUTF_Checks#AreWavesEqual(dimLabel1, dimLabel2, DIMENSION_LABELS, DEFAULT_TOLERANCE, detailedMsg))
+	Ensure(IUTF_Checks#IsProperString(detailedMsg))
+	Ensure(strsearch(detailedMsg, "abcD", 0) >= 0)
 	// @}
 
 	// HasWaveMajorType


### PR DESCRIPTION
We use EqualWaves for comparison of dimension labels and that does it since forever case sensitive.

So we have to also output a difference if the labels only differ in case. Bug introduced in the initial version in 493779da (EQUAL_WAVE_WRAPPER: Work around EqualWaves dimension labels bug, 2019-03-12).

- [x] Add test, VTE?