### PR TITLE
Tracing Analytics: Optimize GetTotals

### DIFF
--- a/procedures/igortest-tracing-analytics.ipf
+++ b/procedures/igortest-tracing-analytics.ipf
@@ -41,7 +41,7 @@ static Function/WAVE GetTotals()
 		endif
 		WAVE entry = entryOuter[0]
 		if(WaveExists(totals))
-			totals += entry
+			FastOp totals += entry
 		else
 			Duplicate/FREE=1 entry, totals
 		endif


### PR DESCRIPTION
Optimize the runtime of `GetTotals()` and `ShowTopFunctions`. The old function profiling result showed this:

```
Total time: 36.1456, Time in Function code: 36.1456 (100%)
Top function percentages:
Function igortest-tracing-analytics.ipf GetTotals: 100%

Annotated Top Functions:

*******************************************************************************************
Function: igortest-tracing-analytics.ipf igortest-tracing-analytics.ipf#GetTotals; Percent total 100%
*******************************************************************************************
[00]          	|static Function/WAVE GetTotals()
[00]          	|	variable i, numWaves
[00]          	|
[00]*         	|	TUFXOP_GetStorage/N="IUTF_TestRun" storage
[00]          	|	numWaves = DimSize(storage, UTF_ROW)
[00]          	|	WAVE/ZZ totals
[00]*         	|	for(i = 0; i < numWaves; i++)
[00]*         	|		WAVE/WAVE/Z entryOuter = storage[i]
[00]*         	|		if(!WaveExists(entryOuter))
[00]*         	|			continue
[00]          	|		endif
[00]*         	|		WAVE entry = entryOuter[0]
[00]*         	|		if(WaveExists(totals))
[100]**********	|			totals += entry
[00]          	|		else
[00]*         	|			Duplicate/FREE=1 entry, totals
[00]          	|		endif
[00]          	|	endfor
[00]          	|
[00]          	|	if(!WaveExists(totals))
[00]          	|		Make/N=0/FREE=1 totals
[00]          	|	endif
[00]          	|
[00]          	|	return totals
[00]          	|End
```

The new function profiling result shows this:

```
Total time: 0.920468, Time in Function code: 0.916994 (99.6%)
Top function percentages:
Function igortest-tracing-analytics.ipf GetTotals: 93%

Annotated Top Functions:

*******************************************************************************************
Function: igortest-tracing-analytics.ipf igortest-tracing-analytics.ipf#GetTotals; Percent total 93%
*******************************************************************************************
[00]          	|static Function/WAVE GetTotals()
[00]          	|	variable i, numWaves
[00]          	|
[00]          	|	TUFXOP_GetStorage/N="IUTF_TestRun" storage
[00]          	|	numWaves = DimSize(storage, UTF_ROW)
[00]          	|	WAVE/ZZ totals
[01]*         	|	for(i = 0; i < numWaves; i++)
[00]*         	|		WAVE/WAVE/Z entryOuter = storage[i]
[00]*         	|		if(!WaveExists(entryOuter))
[00]          	|			continue
[00]          	|		endif
[00]*         	|		WAVE entry = entryOuter[0]
[00]*         	|		if(WaveExists(totals))
[91]********* 	|			FastOp totals += entry
[00]          	|		else
[01]*         	|			Duplicate/FREE=1 entry, totals
[00]          	|		endif
[00]          	|	endfor
[00]          	|
[00]          	|	if(!WaveExists(totals))
[00]          	|		Make/N=0/FREE=1 totals
[00]          	|	endif
[00]          	|
[00]          	|	return totals
[00]          	|End
```

This small fix makes `ShowTopFunctions` about 39 times faster!

Close: #456