### PR TITLE
Autorun: Cleanup previous stored home path

### DIFF
--- a/procedures/igortest-autorun.ipf
+++ b/procedures/igortest-autorun.ipf
@@ -55,6 +55,11 @@ static Function AfterFileOpenHook(refNum, file, pathName, type, creator, kind)
 		return 0
 	endif
 
+	// Clear previous stored home path before checking the autorun mode. The previous stored home
+	// path is unlikely the current home path of this experiment and it won't hurt to clear it at
+	// load time of this experiment.
+	IUTF_Utils_Paths#ClearHomePath()
+
 	autorunMode = GetAutorunMode()
 
 	if(autorunMode == AUTORUN_OFF)


### PR DESCRIPTION
The previous stored home path is unlikely the current home path of the experiment if the experiment is loaded into Igor. The autorun feature relyes on the correct home path to determine if an autorun should be executed or not.

This has been fixed in such a way that the AfterFileOpenHook will always clear the previous stored home path before checking the autorun configuration.

Close: #457