### PR TITLE
Add utility function to unregister the IUTF background monitoring task

### DIFF
--- a/docu/sphinx/source/advanced.rst
+++ b/docu/sphinx/source/advanced.rst
@@ -242,6 +242,12 @@ background tasks that should be monitored. The mode parameter sets if all or one
 task has to finish to continue test execution. Optional a timeout can be set
 after the test continues independently of the user task(s) state.
 
+It might happen that while a test case executes it turns out that a previously
+registered background monitor is not needed any more, e.g. if requirements for
+further parts of the test case are not met. Then an already registered background
+monitor can be unregistered by calling :cpp:func:`UnRegisterIUTFMonitor()` from
+the test case or BEGIN hook. The function takes no arguments.
+
 See also :ref:`flags_IUTFBackgroundMonModes`.
 
 Function definition of RegisterIUTFMonitor

--- a/procedures/igortest-basics.ipf
+++ b/procedures/igortest-basics.ipf
@@ -1349,6 +1349,15 @@ Function RegisterIUTFMonitor(taskList, mode, reentryFunc, [timeout, failOnTimeou
 	CtrlNamedBackground $BACKGROUNDMONTASK, proc=IUTFBackgroundMonitor, period=10, start
 End
 
+/// @brief Unregisters the IUTF background monitor task
+Function UnRegisterIUTFMonitor()
+
+	DFREF dfr = GetPackageFolder()
+	variable/G dfr:BCKG_Registered = 0
+
+	CtrlNamedBackground $BACKGROUNDMONTASK stop
+End
+
 // Checks if a test case can be retried with the given conditions. Returns 1 if the test case can be
 // retried and 0 if not.
 static Function CanRetry(skip, s, fullFuncName, tcResultIndex)


### PR DESCRIPTION
- This allows a test case to revoke a registration of a background task to continue later with a reentry function.

- Added documentation

related to #466