### PR TITLE
Add SKIP_TESTCASE and SKIP_TESTCASE_EXPECT_FAILS assertions

### DIFF
--- a/procedures/igortest-assertions.ipf
+++ b/procedures/igortest-assertions.ipf
@@ -30,6 +30,40 @@ Function FAIL()
 	IUTF_Wrapper#TRUE_WRAPPER(0, REQUIRE_MODE)
 End
 
+/// Skips current test case
+///
+/// The test case is aborted.
+/// Already failed assertions are treated as expected failure.
+/// Any registered reentry is automatically unregistered.
+Function SKIP_TESTCASE_EXPECT_FAILS()
+	IUTF_Basics#SetExpectedFailure(1)
+	WAVE/T wvTestCase = IUTF_Reporting#GetTestCaseWave()
+	wvTestCase[%CURRENT][%STATUS] = IUTF_STATUS_SKIP
+	SKIP_TESTCASE()
+End
+
+/// Skips current test case
+///
+/// The test case is aborted.
+/// Any registered reentry is automatically unregistered.
+Function SKIP_TESTCASE()
+	IUTF_Reporting#IUTF_PrintStatusMessage("Skipping test case")
+	WAVE/T wvTestCase = IUTF_Reporting#GetTestCaseWave()
+	if(!CmpStr(wvTestCase[%CURRENT][%STATUS], IUTF_STATUS_RUNNING))
+		wvTestCase[%CURRENT][%STATUS] = IUTF_STATUS_SKIP
+	endif
+
+	IUTF_Reporting#incrAssert()
+
+	IUTF_Reporting#ShowInfoMsg()
+	IUTF_Reporting#CleanupInfoMsg()
+
+	UnRegisterIUTFMonitor()
+
+	IUTF_Basics#SetAbortFromSkipFlag()
+	Abort
+End
+
 /// Append information to the next assertion to print if failed
 Function INFO(format, [s, n, s0, s1, s2, s3, s4, n0, n1, n2, n3, n4])
 	string format

--- a/procedures/igortest-basics.ipf
+++ b/procedures/igortest-basics.ipf
@@ -289,6 +289,28 @@ static Function InitAbortFlag()
 	variable/G dfr:abortFlag = 0
 End
 
+/// Returns 1 if the abortFromSkipFlag is set and zero otherwise
+static Function IsAbortFromSkip()
+	NVAR/Z/SDFR=GetPackageFolder() abortFromSkipFlag
+	if(NVAR_Exists(abortFromSkipFlag) && abortFromSkipFlag == 1)
+		return 1
+	else
+		return 0
+	endif
+End
+
+/// Sets the abortFromSkipFlag flag
+static Function SetAbortFromSkipFlag()
+	DFREF dfr = GetPackageFolder()
+	variable/G dfr:abortFromSkipFlag = 1
+End
+
+/// Resets the abortFromSkipFlag flag
+static Function InitAbortFromSkipFlag()
+	DFREF dfr = GetPackageFolder()
+	variable/G dfr:abortFromSkipFlag = 0
+End
+
 /// @brief returns 1 if the current testcase is marked as expected failure, zero otherwise
 ///
 /// @returns 1 if the current testcase is marked as expected failure, zero otherwise
@@ -1639,6 +1661,7 @@ Function RunTest(procWinList, [name, testCase, enableJU, enableTAP, enableRegExp
 		ClearBaseFilename()
 		CreateHistoryLog()
 		InitAbortFlag()
+		InitAbortFromSkipFlag()
 		IUTF_Reporting_Control#SetupTestRun()
 
 		allowDebug = ParamIsDefault(allowDebug) ? 0 : !!allowDebug
@@ -1919,7 +1942,7 @@ Function RunTest(procWinList, [name, testCase, enableJU, enableTAP, enableRegExp
 					msg = GetRTErrMessage()
 					s.err = GetRTError(1)
 					// clear the abort code from setAbortFlag()
-					V_AbortCode = shouldDoAbort() ? 0 : V_AbortCode
+					V_AbortCode = shouldDoAbort()  || IsAbortFromSkip() ? 0 : V_AbortCode
 					EvaluateRTE(s.err, msg, V_AbortCode, fullFuncName, IUTF_TEST_CASE_TYPE, procWin)
 
 					if(shouldDoAbort() && !(s.enableTAP && IUTF_TAP#TAP_IsFunctionTodo(fullFuncName)))
@@ -1946,6 +1969,8 @@ Function RunTest(procWinList, [name, testCase, enableJU, enableTAP, enableRegExp
 						WAVE/T wvTestRun = IUTF_Reporting#GetTestRunWave()
 						return str2num(wvTestRun[%CURRENT][%NUM_ERROR])
 					endif
+
+					InitAbortFromSkipFlag()
 				endtry
 
 #if (IgorVersion() >= 9.00) && Exists("TUFXOP_Version") && (NumberByKey("BUILD", IgorInfo(0)) >= 38812)

--- a/procedures/igortest-hooks.ipf
+++ b/procedures/igortest-hooks.ipf
@@ -451,7 +451,9 @@ static Function AfterTestCase(name, skip)
 		else
 			// reset the assertion error counter as all previous errors are intended
 			wvTestCase[%CURRENT][%NUM_ASSERT_ERROR] = "0"
-			wvTestCase[%CURRENT][%STATUS] = IUTF_STATUS_RUNNING
+			if(!CmpStr(wvTestCase[%CURRENT][%STATUS], IUTF_STATUS_FAIL))
+				wvTestCase[%CURRENT][%STATUS] = IUTF_STATUS_RUNNING
+			endif
 		endif
 	else
 		if(str2num(wvTestCase[%CURRENT][%NUM_ASSERT]) == 0)

--- a/procedures/igortest-reporting.ipf
+++ b/procedures/igortest-reporting.ipf
@@ -326,8 +326,6 @@ static Function TestCaseFail(message, [summaryMsg, isFailure, incrErrorCounter])
 	string summaryMsg
 	variable isFailure, incrErrorCounter
 
-	variable i, length
-
 	summaryMsg = SelectString(ParamIsDefault(summaryMsg), summaryMsg, message)
 	isFailure = ParamIsDefault(isFailure) ? 0 : !!isFailure
 	incrErrorCounter = ParamIsDefault(incrErrorCounter) ? 1 : !!incrErrorCounter
@@ -337,13 +335,21 @@ static Function TestCaseFail(message, [summaryMsg, isFailure, incrErrorCounter])
 	// We are increasing the local error counter so there is no need to increase the global error
 	// counter.
 	ReportError(message, incrGlobalErrorCounter = 0)
+	ShowInfoMsg()
+
+	AddFailedSummaryInfo(summaryMsg)
+End
+
+/// Prints message that was stored through the INFO assertion
+static Function ShowInfoMsg()
+
+	variable i, length
+
 	WAVE/T wvInfoMsg = GetInfoMsg()
 	length = IUTF_Utils_Vector#GetLength(wvInfoMsg)
 	for(i = 0; i < length; i += 1)
 		ReportError("  " + TC_ASSERTION_INFO_INDICATOR + " " + wvInfoMsg[i], incrGlobalErrorCounter = 0)
 	endfor
-
-	AddFailedSummaryInfo(summaryMsg)
 End
 
 /// Prints an informative message that the test case failed

--- a/tests/TestResultsTests/EasyTests.ipf
+++ b/tests/TestResultsTests/EasyTests.ipf
@@ -163,3 +163,28 @@ static Function InfoInErrorOutput_Verify()
 	result = tc[0][%STDERR]
 	CHECK(strsearch(result, expect, 0) > -1)
 End
+
+// The following 4 tests rely on consecutive execution in the order of appearance
+static Function TC_SkipTC()
+
+	SKIP_TESTCASE()
+End
+
+static Function TC_SkipTC_Check()
+
+	WAVE/T wvSuite = IUTF_Reporting#GetTestSuiteWave()
+	CHECK_EQUAL_STR(wvSuite[%CURRENT][%NUM_SKIPPED], "1")
+End
+
+
+static Function TC_SkipTCFail()
+
+	CHECK(0)
+	SKIP_TESTCASE_EXPECT_FAILS()
+End
+
+static Function TC_SkipTCFail_Check()
+
+	WAVE/T wvSuite = IUTF_Reporting#GetTestSuiteWave()
+	CHECK_EQUAL_STR(wvSuite[%CURRENT][%NUM_SKIPPED], "2")
+End


### PR DESCRIPTION
Both assertion abort the current testcase. Any registered reentry function is unregistered.

When SKIP_TESTCASE_EXPECT_FAILS is called, previously failed assertions in the same testcase are treated as expected failures.

close #467 