### PR TITLE
Performance Increase

### DIFF
--- a/docu/sphinx/source/code.rst
+++ b/docu/sphinx/source/code.rst
@@ -9,5 +9,4 @@ converted for `sphinx <http://www.sphinx-doc.org>`__ using `breathe
    :maxdepth: 2
 
    assertions
-   helpers
    flags

--- a/docu/sphinx/source/helpers.rst
+++ b/docu/sphinx/source/helpers.rst
@@ -1,8 +1,0 @@
-Helper Functions
-----------------
-
-
-The following Helper Functions are available:
-
-.. doxygengroup:: Helpers
-   :content-only:

--- a/procedures/igortest-assertion-wrappers.ipf
+++ b/procedures/igortest-assertion-wrappers.ipf
@@ -735,7 +735,8 @@ static Function EQUAL_WAVE_WRAPPER(wv1, wv2, flags, [mode, tol])
 	variable mode, tol
 
 	variable i, result
-	string str, detailedMsg, name1, name2
+	string detailedMsg, name1, name2
+	string str = ""
 
 	IUTF_Reporting#incrAssert()
 
@@ -796,12 +797,14 @@ static Function EQUAL_WAVE_WRAPPER(wv1, wv2, flags, [mode, tol])
 		mode = modes[i]
 		result = IUTF_Checks#AreWavesEqual(wv1, wv2, mode, tol, detailedMsg)
 
-		name1 = IUTF_Utils#GetWaveNameInDFStr(wv1)
-		name2 = IUTF_Utils#GetWaveNameInDFStr(wv2)
-		sprintf str, "Assuming equality using mode %s for waves %s and %s", EqualWavesModeToString(mode), name1, name2
+		if(!result)
+			name1 = IUTF_Utils#GetWaveNameInDFStr(wv1)
+			name2 = IUTF_Utils#GetWaveNameInDFStr(wv2)
+			sprintf str, "Assuming equality using mode %s for waves %s and %s", EqualWavesModeToString(mode), name1, name2
 
-		if(!IUTF_Utils#IsEmpty(detailedMsg))
-			str += "; detailed: " + detailedMsg
+			if(!IUTF_Utils#IsEmpty(detailedMsg))
+				str += "; detailed: " + detailedMsg
+			endif
 		endif
 
 		EvaluateResults(result, str, flags, cleanupInfo = 0)

--- a/procedures/igortest-basics.ipf
+++ b/procedures/igortest-basics.ipf
@@ -231,12 +231,14 @@ End
 
 /// Returns the package folder
 Function/DF GetPackageFolder()
-	if(!DataFolderExists(PKG_FOLDER))
-		NewDataFolder/O root:Packages
-		NewDataFolder/O root:Packages:igortest
-	endif
 
 	DFREF dfr = $PKG_FOLDER
+	if(!DataFolderRefStatus(dfr))
+		NewDataFolder/O root:Packages
+		NewDataFolder/O root:Packages:igortest
+		DFREF dfr = $PKG_FOLDER
+	endif
+
 	return dfr
 End
 

--- a/procedures/igortest-debug.ipf
+++ b/procedures/igortest-debug.ipf
@@ -79,48 +79,4 @@ static Function GetCurrentDebuggerState()
 	return (!!V_enable) * IUTF_DEBUG_ENABLE | (!!V_debugOnError) * IUTF_DEBUG_ON_ERROR | (!!V_NVAR_SVAR_WAVE_Checking) * IUTF_DEBUG_NVAR_SVAR_WAVE
 End
 
-/// Returns 1 if debug output is enabled and zero otherwise
-static Function EnabledDebug()
-	DFREF dfr = GetPackageFolder()
-	NVAR/Z/SDFR=dfr verbose
-
-	if(NVAR_EXISTS(verbose) && verbose == 1)
-		return 1
-	endif
-
-	return 0
-End
-
-/// Output debug string in assertions
-/// @param str            debug string
-/// @param booleanValue   assertion state
-static Function DebugOutput(str, booleanValue)
-	string &str
-	variable booleanValue
-
-	if(EnabledDebug())
-		str = str + ": is " + SelectString(booleanValue, "false", "true") + "."
-		IUTF_Reporting#ReportError(str, incrGlobalErrorCounter = 0)
-	elseif(!booleanValue)
-		str = str + ": is false."
-	endif
-End
-
 ///@endcond // HIDDEN_SYMBOL
-
-///@addtogroup Helpers
-///@{
-
-/// Turns debug output on
-Function EnableDebugOutput()
-	DFREF dfr = GetPackageFolder()
-	variable/G dfr:verbose = 1
-End
-
-/// Turns debug output off
-Function DisableDebugOutput()
-	DFREF dfr = GetPackageFolder()
-	variable/G dfr:verbose = 0
-End
-
-///@}

--- a/procedures/igortest-debug.ipf
+++ b/procedures/igortest-debug.ipf
@@ -98,9 +98,11 @@ static Function DebugOutput(str, booleanValue)
 	string &str
 	variable booleanValue
 
-	str = str + ": is " + SelectString(booleanValue, "false", "true") + "."
 	if(EnabledDebug())
+		str = str + ": is " + SelectString(booleanValue, "false", "true") + "."
 		IUTF_Reporting#ReportError(str, incrGlobalErrorCounter = 0)
+	elseif(!booleanValue)
+		str = str + ": is false."
 	endif
 End
 

--- a/procedures/igortest-reporting.ipf
+++ b/procedures/igortest-reporting.ipf
@@ -268,7 +268,6 @@ static Function CleanupInfoMsg()
 	WAVE/T wv = GetInfoMsg()
 
 	IUTF_Utils_Vector#SetLength(wv, 0)
-	wv[] = ""
 End
 
 /// Get or create the wave that contains the failed procedures

--- a/procedures/igortest-reporting.ipf
+++ b/procedures/igortest-reporting.ipf
@@ -502,9 +502,9 @@ static Function ReportResults(result, str, flags, [cleanupInfo, callStack])
 
 	cleanupInfo = ParamIsDefault(cleanupInfo) ? 1 : !!cleanupInfo
 
-	IUTF_Debug#DebugOutput(str, result)
-
 	if(!result)
+
+		str = str + ": is false."
 		expectedFailure = IsExpectedFailure()
 
 		if(flags & OUTPUT_MESSAGE)


### PR DESCRIPTION
These changes increase the performance of the IUTF.
For 1000x CHECK_EQUAL_WAVES for the success case the rough numbers are:

Before: 7.37 s
After: 0.31 s

- [x] remove debugoutput functionality

close #474 
close #472