### PR TITLE
Fix sphinx documentation style

### DIFF
--- a/docu/sphinx/source/_static/custom.css
+++ b/docu/sphinx/source/_static/custom.css
@@ -1,3 +1,16 @@
 dl.function:not(:last-child) {
   margin-bottom: 3em;
 }
+
+@media screen and (max-width: 940px) {
+  div.document {
+    display: flex;
+    flex-direction: column-reverse;
+  }
+
+  div.document div.sphinxsidebar {
+    margin: -20px -30px 20px -30px;
+    width: unset;
+    left: 0;
+  }
+}

--- a/docu/sphinx/source/conf.py
+++ b/docu/sphinx/source/conf.py
@@ -109,7 +109,6 @@ html_theme_options = {
     'github_repo': 'igortest',
     'github_banner': True,
     'show_powered_by': False,
-    'page_width' : '90%',
 }
 
 html_context = {


### PR DESCRIPTION
We have updated our used sphinx and alabaster versions and they had some major breaking changes in the style and our current documentation looks a bit off. These changes ensures that we have the same style like before.