### PR TITLE
Tracing: Fix switch statement tracing to support IP10

### DIFF
--- a/procedures/igortest-basics.ipf
+++ b/procedures/igortest-basics.ipf
@@ -4,6 +4,17 @@
 #pragma TextEncoding="UTF-8"
 #pragma ModuleName=IUTF_Basics
 
+#undef UTF_ALLOW_TRACING
+#if Exists("TUFXOP_Version")
+
+#if IgorVersion() >= 10.00
+#define UTF_ALLOW_TRACING
+#elif (IgorVersion() >= 9.00) && (NumberByKey("BUILD", IgorInfo(0)) >= 38812)
+#define UTF_ALLOW_TRACING
+#endif
+
+#endif
+
 ///@cond HIDDEN_SYMBOL
 
 static Constant FFNAME_OK        = 0x00
@@ -1751,7 +1762,7 @@ Function RunTest(procWinList, [name, testCase, enableJU, enableTAP, enableRegExp
 		s.procWinList = procWinList
 
 		if(s.tracingEnabled)
-#if (exists("TUFXOP_Version") && ((IgorVersion() >= 9.00) && (NumberByKey("BUILD", IgorInfo(0)) >= 38812) || (IgorVersion() >= 10.00)))
+#ifdef UTF_ALLOW_TRACING
 			if(!CmpStr(traceWinList, IUTF_TRACE_REENTRY_KEYWORD))
 				DFREF dfSave = $PKG_FOLDER_SAVE
 				RestoreState(dfSave, s)
@@ -1777,11 +1788,11 @@ Function RunTest(procWinList, [name, testCase, enableJU, enableTAP, enableRegExp
 			endif
 #else
 			IUTF_Reporting#ReportErrorAndAbort("Tracing requires Igor Pro 9 Build 38812 (or later) and the Thread Utilities XOP.")
-#endif
+#endif // UTF_ALLOW_TRACING
 		else
-#if (exists("TUFXOP_Version") && ((IgorVersion() >= 9.00) && (NumberByKey("BUILD", IgorInfo(0)) >= 38812) || (IgorVersion() >= 10.00)))
+#ifdef UTF_ALLOW_TRACING
 			TUFXOP_Init/N="IUTF_Testrun"
-#endif
+#endif // UTF_ALLOW_TRACING
 		endif
 
 		// below here use only s. variables to keep local state in struct
@@ -1973,7 +1984,7 @@ Function RunTest(procWinList, [name, testCase, enableJU, enableTAP, enableRegExp
 					InitAbortFromSkipFlag()
 				endtry
 
-#if (exists("TUFXOP_Version") && ((IgorVersion() >= 9.00) && (NumberByKey("BUILD", IgorInfo(0)) >= 38812) || (IgorVersion() >= 10.00)))
+#ifdef UTF_ALLOW_TRACING
 				// check if Z_ has stored some errors
 				if(s.tracingEnabled)
 					TUFXOP_GetStorage/Z/Q/N="IUTF_Error" wvAllStorage
@@ -1986,7 +1997,7 @@ Function RunTest(procWinList, [name, testCase, enableJU, enableTAP, enableRegExp
 						endfor
 					endif
 				endif
-#endif
+#endif // UTF_ALLOW_TRACING
 
 			endif
 
@@ -2042,14 +2053,14 @@ Function RunTest(procWinList, [name, testCase, enableJU, enableTAP, enableRegExp
 
 	ClearReentrytoIUTF()
 
-#if (exists("TUFXOP_Version") && ((IgorVersion() >= 9.00) && (NumberByKey("BUILD", IgorInfo(0)) >= 38812) || (IgorVersion() >= 10.00)))
+#ifdef UTF_ALLOW_TRACING
 	if(s.htmlCreation)
 		IUTF_Tracing#AnalyzeTracingResult()
 	endif
 	if(s.cobertura)
 		IUTF_Tracing_Cobertura#PrintReport(s.coberturaSources, s.coberturaOut)
 	endif
-#endif
+#endif // UTF_ALLOW_TRACING
 
 	QuitOnAutoRunFull()
 

--- a/procedures/igortest-tracing-analytics.ipf
+++ b/procedures/igortest-tracing-analytics.ipf
@@ -4,7 +4,18 @@
 #pragma version=1.10
 #pragma ModuleName=IUTF_Tracing_Analytics
 
-#if (exists("TUFXOP_Version") && ((IgorVersion() >= 9.00) && (NumberByKey("BUILD", IgorInfo(0)) >= 38812) || (IgorVersion() >= 10.00)))
+#undef UTF_ALLOW_TRACING
+#if Exists("TUFXOP_Version")
+
+#if IgorVersion() >= 10.00
+#define UTF_ALLOW_TRACING
+#elif (IgorVersion() >= 9.00) && (NumberByKey("BUILD", IgorInfo(0)) >= 38812)
+#define UTF_ALLOW_TRACING
+#endif
+
+#endif
+
+#ifdef UTF_ALLOW_TRACING
 
 static Structure CollectionResult
 	WAVE/T functions
@@ -311,4 +322,4 @@ Function ShowTopFunctions(variable count, [variable mode, variable sorting])
 	IUTF_Reporting#IUTF_PrintStatusMessage(msg)
 End
 
-#endif
+#endif // UTF_ALLOW_TRACING

--- a/procedures/igortest-tracing-cobertura.ipf
+++ b/procedures/igortest-tracing-cobertura.ipf
@@ -4,7 +4,18 @@
 #pragma version=1.10
 #pragma ModuleName=IUTF_Tracing_Cobertura
 
-#if (exists("TUFXOP_Version") && ((IgorVersion() >= 9.00) && (NumberByKey("BUILD", IgorInfo(0)) >= 38812) || (IgorVersion() >= 10.00)))
+#undef UTF_ALLOW_TRACING
+#if Exists("TUFXOP_Version")
+
+#if IgorVersion() >= 10.00
+#define UTF_ALLOW_TRACING
+#elif (IgorVersion() >= 9.00) && (NumberByKey("BUILD", IgorInfo(0)) >= 38812)
+#define UTF_ALLOW_TRACING
+#endif
+
+#endif
+
+#ifdef UTF_ALLOW_TRACING
 
 // file size limit to show a warning banner. Some Cobertura consumers like Gitlab have a hardcoded
 // limit after which no cobertura files can no longer be read. The limit for Gitlab is at 10 MB but
@@ -358,4 +369,4 @@ static Function PrintReport(string sources, string outDir)
 	IUTF_Reporting#IUTF_PrintStatusMessage("Cobertura export finished.")
 End
 
-#endif
+#endif // UTF_ALLOW_TRACING

--- a/procedures/igortest-tracing-tracer.ipf
+++ b/procedures/igortest-tracing-tracer.ipf
@@ -4,7 +4,18 @@
 #pragma version=1.10
 #pragma ModuleName=IUTF_Tracer
 
-#if (exists("TUFXOP_Version") && ((IgorVersion() >= 9.00) && (NumberByKey("BUILD", IgorInfo(0)) >= 38812) || (IgorVersion() >= 10.00)))
+#undef UTF_ALLOW_TRACING
+#if Exists("TUFXOP_Version")
+
+#if IgorVersion() >= 10.00
+#define UTF_ALLOW_TRACING
+#elif (IgorVersion() >= 9.00) && (NumberByKey("BUILD", IgorInfo(0)) >= 38812)
+#define UTF_ALLOW_TRACING
+#endif
+
+#endif
+
+#ifdef UTF_ALLOW_TRACING
 
 /// @brief Calls to this function are inserted into code where code coverage is logged.
 ///        These calls are auto generated and contain information about the procedure and line number
@@ -91,4 +102,4 @@ threadsafe Function Z_(variable procNum, variable lineNum, [variable c, variable
 
 	return c
 End
-#endif
+#endif // UTF_ALLOW_TRACING

--- a/procedures/igortest-tracing.ipf
+++ b/procedures/igortest-tracing.ipf
@@ -4,7 +4,18 @@
 #pragma version=1.10
 #pragma ModuleName=IUTF_Tracing
 
-#if (exists("TUFXOP_Version") && ((IgorVersion() >= 9.00) && (NumberByKey("BUILD", IgorInfo(0)) >= 38812) || (IgorVersion() >= 10.00)))
+#undef UTF_ALLOW_TRACING
+#if Exists("TUFXOP_Version")
+
+#if IgorVersion() >= 10.00
+#define UTF_ALLOW_TRACING
+#elif (IgorVersion() >= 9.00) && (NumberByKey("BUILD", IgorInfo(0)) >= 38812)
+#define UTF_ALLOW_TRACING
+#endif
+
+#endif
+
+#ifdef UTF_ALLOW_TRACING
 
 static StrConstant PROC_BACKUP_ENDING  = ".backup"
 static StrConstant FUNCTION_TAG_PREFIX = "IUTF_TagFunc_"
@@ -1124,4 +1135,4 @@ static Function GetCyclomaticComplexity(string codeLine)
 	return complexity
 End
 
-#endif
+#endif // UTF_ALLOW_TRACING

--- a/procedures/igortest-tracing.ipf
+++ b/procedures/igortest-tracing.ipf
@@ -31,7 +31,8 @@ static Constant STAT_COVERED = 1
 static StrConstant COMPILER_DIRECTIVE_PATTERN = "^\\s*#.*$"
 
 // The pattern for comments
-static StrConstant COMMENT_PATTERN = "//.*$"
+static StrConstant COMMENT_PATTERN      = "//.*$"
+static StrConstant PURE_COMMENT_PATTERN = "^\\s*//.*$"
 
 // The pattern to find strings in the code line. This pattern consists of the following parts:
 //
@@ -55,6 +56,25 @@ static StrConstant STRING_PATTERN = "(?<=\")(?:[^\"\\\\]|\\\\.)*(?=\")"
 //
 // Remember to escape \ into \\!
 static StrConstant COMPLEX_PATTERN = "(?i)(?:(?<!\\w)(?:Function|if|elseif|while|for|case|SelectString|SelectNumber|catch)(?!\\w)|&&|\\|\\||\\?)"
+
+// This pattern checks for all switch, strswitch or break statements that create a region for which
+// no Z_ function is allowed. The pattern consists of the following constructs:
+//
+// - (?i)(?:  )*()                          Building block for global pattern. The first non capture
+//                                          group is used for exclusion.
+// - (?:[^\"\\r\\n\\/]|\\/[^\\/]|\"(?:[^\"\\\\]|\\\\.)*\")*
+//                                          This is used to prevent matching a keyword in invalid
+//                                          regions. For that we collect all known regions from the
+//                                          start of the line.
+// - [^\"\\r\\n\\/]                         Matches all characters except " (used for strings),
+//                                          / (used for comments) and line terminations
+// - \\/[^\\/]                              Allow a single / if no other / follows it (prevent comments)
+// - \"(?:[^\"\\\\]|\\\\.)*\"               Matches a whole string
+// - ((?:str)?switch|break)                 Matches strswitch, switch and break
+static StrConstant NO_Z_REGION_PATTERN = "(?i)^(?:[^\"\\r\\n\\/]|\\/[^\\/]|\"(?:[^\"\\\\]|\\\\.)*\")*((?:str)?switch|break)"
+
+// Matches a whole line consisting out of only whitespaces.
+static StrConstant SPACE_ONLY_PATTERN = "^\\w*$"
 
 static Function SetupTracing(string procWinList, string traceOptions)
 
@@ -585,6 +605,7 @@ static Function [WAVE/T w, string funcPath_, WAVE marker_] AddTraceFunctions(str
 
 	for(i = 0; i < numFunc; i += 1)
 		WAVE/T wFuncText = funcTexts[i]
+		[WAVE exclusionLines] = DetectExcludedLines(wFuncText)
 
 		// Add lines before function
 		preFuncLines = ""
@@ -625,7 +646,7 @@ static Function [WAVE/T w, string funcPath_, WAVE marker_] AddTraceFunctions(str
 			doNextLine      = 0
 			currProcLineNum = currFuncLineNum + funcLineStart[i]
 
-			if(funcExclusionFlag[i])
+			if(funcExclusionFlag[i] || exclusionLines[j])
 				newProcCode += AddNoZ(origLines, lineCnt)
 				continue
 			endif
@@ -790,6 +811,34 @@ static Function/S AddZ(WAVE marker, string &origLines, variable currLineNum, var
 	lineCnt   = 1
 
 	return newCode
+End
+
+static Function [WAVE/Z exclusionLines] DetectExcludedLines(WAVE/T funcText)
+	variable i, noZRegion
+
+	variable lines = DimSize(funcText, UTF_ROW)
+	Make/FREE/N=(lines) exclusionLines
+
+	for(i = 0; i < lines; i++)
+		// detect empty line or one that has only whitespaces
+		if(GrepString(funcText[i], SPACE_ONLY_PATTERN))
+			exclusionLines[i] = 1
+			continue
+		endif
+		// detect lines with compiler directives
+		if(GrepString(funcText[i], COMPILER_DIRECTIVE_PATTERN))
+			exclusionLines[i] = 1
+			continue
+		endif
+		// detect lines with pure comment
+		if(GrepString(funcText[i], PURE_COMMENT_PATTERN))
+			// if we have a no Z_ region we have to exclude this line
+			exclusionLines[i] = noZRegion
+			continue
+		endif
+		// check if we have a new no Z region pattern. If not, we discard any previous settings
+		noZRegion = GrepString(funcText[i], NO_Z_REGION_PATTERN)
+	endfor
 End
 
 /// @brief Parses a line after Function was encountered for declaration names and returns 1 if it is related to the function variable declaration

--- a/tests/IMUnitTests/im-main.ipf
+++ b/tests/IMUnitTests/im-main.ipf
@@ -16,7 +16,18 @@ Function run(procedures, allowDebug, waveTrackingMode)
 	RunTest(procedures, name = "IM Unit Tests", enableJU = 1, enableRegExp = 1, allowDebug = allowDebug, waveTrackingMode = waveTrackingMode)
 End
 
-#if (exists("TUFXOP_Version") && ((IgorVersion() >= 9.00) && (NumberByKey("BUILD", IgorInfo(0)) >= 38812) || (IgorVersion() >= 10.00)))
+#undef UTF_ALLOW_TRACING
+#if Exists("TUFXOP_Version")
+
+#if IgorVersion() >= 10.00
+#define UTF_ALLOW_TRACING
+#elif (IgorVersion() >= 9.00) && (NumberByKey("BUILD", IgorInfo(0)) >= 38812)
+#define UTF_ALLOW_TRACING
+#endif
+
+#endif
+
+#ifdef UTF_ALLOW_TRACING
 
 Function TEST_END_OVERRIDE(name)
 	string name
@@ -31,4 +42,4 @@ Function TEST_END_OVERRIDE(name)
 	Execute "ProcGlobal#cleanup()"
 End
 
-#endif
+#endif // UTF_ALLOW_TRACING

--- a/tests/IMUnitTests/main.ipf
+++ b/tests/IMUnitTests/main.ipf
@@ -6,6 +6,17 @@
 
 #include "igortest"
 
+#undef UTF_ALLOW_TRACING
+#if Exists("TUFXOP_Version")
+
+#if IgorVersion() >= 10.00
+#define UTF_ALLOW_TRACING
+#elif (IgorVersion() >= 9.00) && (NumberByKey("BUILD", IgorInfo(0)) >= 38812)
+#define UTF_ALLOW_TRACING
+#endif
+
+#endif
+
 // The setup for Instrumentation in IM are a bit complex because Igor creates a copy of the igortest
 // procedure files when launching an IM and no instrumentation does work after that. It is also a
 // bit tricky to jump right after the instrumentation only process as we need to know that all
@@ -23,7 +34,7 @@ Function run()
 
 	string msg
 
-#if (exists("TUFXOP_Version") && ((IgorVersion() >= 9.00) && (NumberByKey("BUILD", IgorInfo(0)) >= 38812) || (IgorVersion() >= 10.00)))
+#ifdef UTF_ALLOW_TRACING
 
 	// Instrument igortest files and use CallRun2 as test case
 	string traceProcedures = "igortest-(?(?=tracing\\.ipf)|.*)"
@@ -36,7 +47,7 @@ Function run()
 #else
 	string traceProcedures = ""
 	string tracingOp       = ""
-#endif
+#endif // UTF_ALLOW_TRACING
 
 	// backup and clear autorun state to prevent the first RunTest closing Igor
 	if(GetAutorunMode() == AUTORUN_FULL)
@@ -105,9 +116,9 @@ End
 
 Function cleanup()
 
-#if (exists("TUFXOP_Version") && ((IgorVersion() >= 9.00) && (NumberByKey("BUILD", IgorInfo(0)) >= 38812) || (IgorVersion() >= 10.00)))
+#ifdef UTF_ALLOW_TRACING
 	IUTF_RestoreTracing()
-#endif
+#endif // UTF_ALLOW_TRACING
 
 End
 

--- a/tests/Tracing.ipf
+++ b/tests/Tracing.ipf
@@ -4,7 +4,19 @@
 #pragma version=1.10
 #pragma ModuleName=UTF_TestTracing
 
-#if (exists("TUFXOP_Version") && ((IgorVersion() >= 9.00) && (NumberByKey("BUILD", IgorInfo(0)) >= 38812) || (IgorVersion() >= 10.00)))
+#undef UTF_ALLOW_TRACING
+#if Exists("TUFXOP_Version")
+
+#if IgorVersion() >= 10.00
+#define UTF_ALLOW_TRACING
+#elif (IgorVersion() >= 9.00) && (NumberByKey("BUILD", IgorInfo(0)) >= 38812)
+#define UTF_ALLOW_TRACING
+#endif
+
+#endif
+
+#ifdef UTF_ALLOW_TRACING
+
 static Function/S TracingTestLoadFile(string fName)
 	variable fNum
 	string   data

--- a/tests/UnitTests/Tracing/CoberturaTests.ipf
+++ b/tests/UnitTests/Tracing/CoberturaTests.ipf
@@ -4,7 +4,18 @@
 #pragma version=1.10
 #pragma ModuleName=TEST_Tracing_Cobertura
 
-#if (exists("TUFXOP_Version") && ((IgorVersion() >= 9.00) && (NumberByKey("BUILD", IgorInfo(0)) >= 38812) || (IgorVersion() >= 10.00)))
+#undef UTF_ALLOW_TRACING
+#if Exists("TUFXOP_Version")
+
+#if IgorVersion() >= 10.00
+#define UTF_ALLOW_TRACING
+#elif (IgorVersion() >= 9.00) && (NumberByKey("BUILD", IgorInfo(0)) >= 38812)
+#define UTF_ALLOW_TRACING
+#endif
+
+#endif
+
+#ifdef UTF_ALLOW_TRACING
 
 static Function Test_FilePathToXml()
 	string result, expect
@@ -185,4 +196,4 @@ static Function Test_GetLinesReport_Empty()
 	CHECK_EQUAL_VAR(0, metrics.branchValid)
 End
 
-#endif
+#endif // UTF_ALLOW_TRACING

--- a/tests/UnitTests/Tracing/ComplexityTests.ipf
+++ b/tests/UnitTests/Tracing/ComplexityTests.ipf
@@ -4,7 +4,18 @@
 #pragma version=1.10
 #pragma ModuleName=TEST_Tracing_Complexity
 
-#if (exists("TUFXOP_Version") && ((IgorVersion() >= 9.00) && (NumberByKey("BUILD", IgorInfo(0)) >= 38812) || (IgorVersion() >= 10.00)))
+#undef UTF_ALLOW_TRACING
+#if Exists("TUFXOP_Version")
+
+#if IgorVersion() >= 10.00
+#define UTF_ALLOW_TRACING
+#elif (IgorVersion() >= 9.00) && (NumberByKey("BUILD", IgorInfo(0)) >= 38812)
+#define UTF_ALLOW_TRACING
+#endif
+
+#endif
+
+#ifdef UTF_ALLOW_TRACING
 
 static Function Test_Complexity_Simple()
 	// statements that have no influence into the complexity
@@ -66,4 +77,4 @@ static Function Test_Complexity_Casing()
 	CHECK_EQUAL_VAR(1, IUTF_Tracing#GetCyclomaticComplexity("\tcatcH"))
 End
 
-#endif
+#endif // UTF_ALLOW_TRACING

--- a/tests/UnitTests/main.ipf
+++ b/tests/UnitTests/main.ipf
@@ -11,15 +11,26 @@
 #include ":Utils:PathsTests"
 #include ":Utils:StringsTests"
 
+#undef UTF_ALLOW_TRACING
+#if Exists("TUFXOP_Version")
+
+#if IgorVersion() >= 10.00
+#define UTF_ALLOW_TRACING
+#elif (IgorVersion() >= 9.00) && (NumberByKey("BUILD", IgorInfo(0)) >= 38812)
+#define UTF_ALLOW_TRACING
+#endif
+
+#endif
+
 Function run()
 	variable allowDebug = 0
 	string   procedures = ".*Tests\\.ipf"
 
-#if (exists("TUFXOP_Version") && ((IgorVersion() >= 9.00) && (NumberByKey("BUILD", IgorInfo(0)) >= 38812) || (IgorVersion() >= 10.00)))
+#ifdef UTF_ALLOW_TRACING
 	string traceProcedures = "(?:" + procedures + "|igortest-(?(?=tracing\\.ipf)|.*))"
 #else
 	string traceProcedures = ""
-#endif
+#endif // UTF_ALLOW_TRACING
 
 #if IgorVersion() >= 9.00
 	variable waveTrackingMode = UTF_WAVE_TRACKING_ALL
@@ -49,9 +60,9 @@ End
 
 Function cleanup()
 
-#if (exists("TUFXOP_Version") && ((IgorVersion() >= 9.00) && (NumberByKey("BUILD", IgorInfo(0)) >= 38812) || (IgorVersion() >= 10.00)))
+#ifdef UTF_ALLOW_TRACING
 	IUTF_RestoreTracing()
-#endif
+#endif // UTF_ALLOW_TRACING
 
 End
 

--- a/tests/test-tracing.ipf
+++ b/tests/test-tracing.ipf
@@ -8,7 +8,18 @@
 
 // IPT_FORMAT_OFF
 
-#if (exists("TUFXOP_Version") && ((IgorVersion() >= 9.00) && (NumberByKey("BUILD", IgorInfo(0)) >= 38812) || (IgorVersion() >= 10.00)))
+#undef UTF_ALLOW_TRACING
+#if Exists("TUFXOP_Version")
+
+#if IgorVersion() >= 10.00
+#define UTF_ALLOW_TRACING
+#elif (IgorVersion() >= 9.00) && (NumberByKey("BUILD", IgorInfo(0)) >= 38812)
+#define UTF_ALLOW_TRACING
+#endif
+
+#endif
+
+#ifdef UTF_ALLOW_TRACING
 
 // Before Constants
 static Constant NUMCONST = 1

--- a/tests/test-tracing.ipf
+++ b/tests/test-tracing.ipf
@@ -121,9 +121,11 @@ End
 static Function switchtest()
 
 	switch(1)
+		// cmt
 		case 1:
 			print "case"
 			break
+			// cmt
 		default:
 			print "default"
 			break

--- a/tests/test-tracing2.ipf
+++ b/tests/test-tracing2.ipf
@@ -8,7 +8,18 @@
 
 // IPT_FORMAT_OFF
 
-#if (exists("TUFXOP_Version") && ((IgorVersion() >= 9.00) && (NumberByKey("BUILD", IgorInfo(0)) >= 38812) || (IgorVersion() >= 10.00)))
+#undef UTF_ALLOW_TRACING
+#if Exists("TUFXOP_Version")
+
+#if IgorVersion() >= 10.00
+#define UTF_ALLOW_TRACING
+#elif (IgorVersion() >= 9.00) && (NumberByKey("BUILD", IgorInfo(0)) >= 38812)
+#define UTF_ALLOW_TRACING
+#endif
+
+#endif
+
+#ifdef UTF_ALLOW_TRACING
 
 // Outside of Function comment
 

--- a/tests/test-tracing_instrumented.ipf
+++ b/tests/test-tracing_instrumented.ipf
@@ -31,29 +31,29 @@ endstructure
 
 // Before Function 1
 threadsafe Function Function1()
-Z_(0, 21)
-Z_(0, 22)
+Z_(0, 32)
+Z_(0, 33)
 End
 // After Function 1
 
 // Before Function 2
 threadsafe static Function Function2()
-Z_(0, 26)
-Z_(0, 27)
+Z_(0, 37)
+Z_(0, 38)
 End
 // After Function 2
 
 // Before Function 3
 Function Function3_TESTTRACING()
-Z_(0, 31)
-Z_(0, 32)
+Z_(0, 42)
+Z_(0, 43)
 End
 // After Function 3
 
 // Before Function 4
 static Function Function4()
-Z_(0, 36)
-Z_(0, 37)
+Z_(0, 47)
+Z_(0, 48)
 End
 // After Function 4
 
@@ -73,18 +73,18 @@ static Function paramTest1(val, str, w, dfr, f, s, c, wc, wt, i, i64, ui64, d, c
 	double d
 	complex comp
 
-Z_(0, 40)
-Z_(0, 59)
-Z_(0, 56)
+Z_(0, 51)
+Z_(0, 70)
+Z_(0, 67)
 	variable local
 
-Z_(0, 58)
+Z_(0, 69)
 	print "So many parameters"
 End
 
 static Function [DFREF dfr, STRUCT struct_TESTTRACING s] paramTest2()
-Z_(0, 61)
-Z_(0, 62)
+Z_(0, 72)
+Z_(0, 73)
 End
 
 #if IgorVersion() < 9
@@ -96,9 +96,9 @@ End
 #else
 // Before Function 6
 static Function Function6b()
-Z_(0, 72)
-Z_(0, 74)
-Z_(0, 73)
+Z_(0, 83)
+Z_(0, 85)
+Z_(0, 84)
 	print "nine"
 End
 // After Function 6
@@ -106,151 +106,150 @@ End
 
 // Before Function 7
 static Function Function7()
-Z_(0, 79)
-Z_(0, 85)
-Z_(0, 80)
+Z_(0, 90)
+Z_(0, 96)
 #if IgorVersion() < 9
-Z_(0, 81)
+Z_(0, 92)
 	print "not nine"
 #else
-Z_(0, 82)
-Z_(0, 83)
+Z_(0, 94)
 	print "nine"
 #endif
-Z_(0, 84)
 End
 // After Function 7
 
 static Function iftest()
-Z_(0, 88)
-Z_(0, 107)
+Z_(0, 99)
+Z_(0, 118)
 
-	if(Z_(0, 90, c=(1 == (1 + 0))))
-Z_(0, 91)
+	if(Z_(0, 101, c=(1 == (1 + 0))))
+Z_(0, 102)
 		print "1"
-	elseif(Z_(0, 92, c=(1)))
-Z_(0, 93)
+	elseif(Z_(0, 103, c=(1)))
+Z_(0, 104)
 		print "2"
 	else
-Z_(0, 94)
-Z_(0, 95)
+Z_(0, 105)
+Z_(0, 106)
 		print "3"
 	endif
-Z_(0, 96)
+Z_(0, 107)
 
-	if (Z_(0, 98, c=(1 == (1 + 0))))
-Z_(0, 99)
+	if (Z_(0, 109, c=(1 == (1 + 0))))
+Z_(0, 110)
 		print "4"
-	elseif (Z_(0, 100, c=(1)))
-Z_(0, 101)
+	elseif (Z_(0, 111, c=(1)))
+Z_(0, 112)
 		print "5"
 	else
-Z_(0, 102)
-Z_(0, 103)
+Z_(0, 113)
+Z_(0, 114)
 		print "6"
 	endif
-Z_(0, 104)
+Z_(0, 115)
 
-Z_(0, 106)
+Z_(0, 117)
 	print "7"
 End
 
 static Function switchtest()
-Z_(0, 109)
-Z_(0, 134)
+Z_(0, 120)
+Z_(0, 147)
 
-Z_(0, 111)
-	switch(1)
-		case 1:
-Z_(0, 112)
-Z_(0, 113)
-			print "case"
-Z_(0, 114)
-			break
-		default:
-Z_(0, 115)
-Z_(0, 116)
-			print "default"
-Z_(0, 117)
-			break
-	endswitch
-Z_(0, 118)
-Z_(0, 119)
-	print "after endswitch"
-
-Z_(0, 121)
-	switch(1)
-		case 1:
 Z_(0, 122)
-Z_(0, 123)
-			print "case"
+	switch(1)
+		// cmt
+		case 1:
 Z_(0, 124)
-			break
-		default :
 Z_(0, 125)
+			print "case"
 Z_(0, 126)
-			print "default"
-Z_(0, 127)
 			break
-	endswitch;
+			// cmt
+		default:
 Z_(0, 128)
 Z_(0, 129)
+			print "default"
+Z_(0, 130)
+			break
+	endswitch
+Z_(0, 131)
+Z_(0, 132)
 	print "after endswitch"
 
-Z_(0, 131)
+Z_(0, 134)
+	switch(1)
+		case 1:
+Z_(0, 135)
+Z_(0, 136)
+			print "case"
+Z_(0, 137)
+			break
+		default :
+Z_(0, 138)
+Z_(0, 139)
+			print "default"
+Z_(0, 140)
+			break
+	endswitch;
+Z_(0, 141)
+Z_(0, 142)
+	print "after endswitch"
+
+Z_(0, 144)
 	switch(1)
 	endswitch ;
-Z_(0, 132)
-Z_(0, 133)
+Z_(0, 145)
+Z_(0, 146)
 	print "after endswitch"
 End
 
 static Function commenttest()
-Z_(0, 136)
-Z_(0, 143)
+Z_(0, 149)
+Z_(0, 156)
 
-Z_(0, 138)
+Z_(0, 151)
 	// Here we have some
-Z_(0, 139)
+Z_(0, 152)
 	// important comments
-Z_(0, 140)
+Z_(0, 153)
 	// to test the
-Z_(0, 141)
+Z_(0, 154)
 	// instrumentation
-Z_(0, 142)
+Z_(0, 155)
 	print "commenttest end"
 End
 
 // Before TraceMacroTest
 Macro TraceMacroTest()
-Z_(0, 146)
-Z_(0, 150)
-Z_(0, 147)
+Z_(0, 159)
+Z_(0, 163)
+Z_(0, 160)
 	print "1"
 
-Z_(0, 149)
+Z_(0, 162)
 	print "2"
 EndMacro
 
 // Before TraceWindowTest
 Window TraceWindowTest() : Panel
-Z_(0, 153)
-Z_(0, 157)
-Z_(0, 154)
+Z_(0, 166)
+Z_(0, 170)
+Z_(0, 167)
 	print "1"
 
-Z_(0, 156)
+Z_(0, 169)
 	print "2"
 EndMacro
 
 // Before TraceProcTest
 Proc TraceProcTest()
-Z_(0, 160)
-Z_(0, 164)
-Z_(0, 161)
+Z_(0, 173)
+Z_(0, 177)
+Z_(0, 174)
 	print "1"
 
-Z_(0, 163)
+Z_(0, 176)
 	print "2"
 EndMacro
 

--- a/tests/test-tracing_instrumented.ipf
+++ b/tests/test-tracing_instrumented.ipf
@@ -8,7 +8,18 @@
 
 // IPT_FORMAT_OFF
 
-#if (exists("TUFXOP_Version") && ((IgorVersion() >= 9.00) && (NumberByKey("BUILD", IgorInfo(0)) >= 38812) || (IgorVersion() >= 10.00)))
+#undef UTF_ALLOW_TRACING
+#if Exists("TUFXOP_Version")
+
+#if IgorVersion() >= 10.00
+#define UTF_ALLOW_TRACING
+#elif (IgorVersion() >= 9.00) && (NumberByKey("BUILD", IgorInfo(0)) >= 38812)
+#define UTF_ALLOW_TRACING
+#endif
+
+#endif
+
+#ifdef UTF_ALLOW_TRACING
 
 // Before Constants
 static Constant NUMCONST = 1


### PR DESCRIPTION
With Igor 10 there is no code in specific regions of a switch statements allowed:

```igorpro
switch(condition)
    print "no code supported here"
    case VAR:
        print "normal code"
        break
        print "no code supported here"
endswitch
```

Our tracing logic added Z_ function calls in such regions and therefore is a
logic added that prevents the addition of such. This fix does the following
changes to the coverage report:

- All comments, that are located in regions that do not support the execution of
  Z_ functions (like certain regions in switch statements), are uncoverable.
- All compiler pragmas like #if and #else are now uncoverable.

Uncoverable lines are excluded from coverage report and will be rendered gray in
most visualizations.

This fix might change the overall code coverage slightly. This isn't the case if
you already had a code coverage of 100%.

Close #492